### PR TITLE
Removed deprecated use of PropTypes in react error message.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node": ">= 5.11.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   }

--- a/src/Step.js
+++ b/src/Step.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 
 export default class Step extends Component {
   constructor() {

--- a/src/Stepper.js
+++ b/src/Stepper.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import { PropTypes } from 'prop-types';
 
 import Step from './Step';
 


### PR DESCRIPTION
Added third party prop-types npm package to accomplish same tasks as using PropTypes from React. Once merged just run `npm install` and everything should be functioning the same as before, but without any compilation complaints.