### PR TITLE
Borders!

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Well-designed stepper component for react
 ## Installation
 ```
 npm install react-stepper-horizontal --save
-``` 
+```
 Then just add `import Stepper from 'react-stepper-horizontal';` into your file.
 
 ## Screenshot
@@ -45,7 +45,15 @@ See full example [here](https://github.com/mu29/react-stepper/blob/master/exampl
 |defaultTitleOpacity|Default title opacity|1|string|
 |completeTitleOpacity|Completed title opacity|1|string|
 |activeTitleOpacity|Active title opacity|1|string|
-|barStyle|Style of bar seperating steps|solid|string|
+|barStyle|Style of bar separating steps|solid|string|
+|defaultBorderColor|Default color of border surrounding circle||string|
+|completeBorderColor|Color of border surrounding completed circle||string|
+|activeBorderColor|Color of border surrounding active circle||string|
+|defaultBorderStyle|Default style of border surrounding circle|solid|string|
+|completeBorderStyle|Style of border surrounding completed circle|solid|string|
+|activeBorderStyle|Style of border surrounding active circle|solid|string|
+|defaultBarColor|Default color of bar separating circles|#E0E0E0|string|
+
 
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ See full example [here](https://github.com/mu29/react-stepper/blob/master/exampl
 |titleFontSize|Title text size|16|number|
 |circleTop|Top margin of `Stepper` component|24|number|
 |titleTop|Space between circle and title|8|number|
-|defaultOpacity|Default cirlce opacity|1|string|
-|completeOpacity|Completed cirlce opacity|1|string|
-|activeOpacity|Active cirlce opacity|1|string|
+|defaultOpacity|Default circle opacity|1|string|
+|completeOpacity|Completed circle opacity|1|string|
+|activeOpacity|Active circle opacity|1|string|
 |defaultTitleOpacity|Default title opacity|1|string|
 |completeTitleOpacity|Completed title opacity|1|string|
 |activeTitleOpacity|Active title opacity|1|string|
@@ -53,7 +53,7 @@ See full example [here](https://github.com/mu29/react-stepper/blob/master/exampl
 |completeBorderStyle|Style of border surrounding completed circle|solid|string|
 |activeBorderStyle|Style of border surrounding active circle|solid|string|
 |defaultBarColor|Default color of bar separating circles|#E0E0E0|string|
-
+|completeBarColor|Color of bar connected to a completed step|#E0E0E0|string|
 
 
 ## Author

--- a/lib/Step.js
+++ b/lib/Step.js
@@ -55,7 +55,14 @@ var Step = function (_Component) {
           completeTitleOpacity = _props.completeTitleOpacity,
           activeTitleOpacity = _props.activeTitleOpacity,
           defaultTitleOpacity = _props.defaultTitleOpacity,
-          barStyle = _props.barStyle;
+          barStyle = _props.barStyle,
+          barColor = _props.barColor,
+          defaultBorderColor = _props.defaultBorderColor,
+          completeBorderColor = _props.completeBorderColor,
+          activeBorderColor = _props.activeBorderColor,
+          defaultBorderStyle = _props.defaultBorderStyle,
+          completeBorderStyle = _props.completeBorderStyle,
+          activeBorderStyle = _props.activeBorderStyle;
 
 
       return {
@@ -76,15 +83,24 @@ var Step = function (_Component) {
           fontSize: circleFontSize,
           color: circleFontColor,
           display: 'block',
-          opacity: defaultOpcaity
+          opacity: defaultOpcaity,
+          borderWidth: defaultBorderColor ? 3 : 0,
+          borderColor: defaultBorderColor,
+          borderStyle: defaultBorderStyle
         },
         activeCircle: {
           backgroundColor: activeColor,
-          opacity: activeOpacity
+          opacity: activeOpacity,
+          borderWidth: activeBorderColor ? 3 : 0,
+          borderColor: activeBorderColor,
+          borderStyle: activeBorderStyle
         },
         completedCircle: {
           backgroundColor: completeColor,
-          opacity: completeOpacity
+          opacity: completeOpacity,
+          borderWidth: completeBorderColor ? 3 : 0,
+          borderColor: completeBorderColor,
+          borderStyle: completeBorderStyle
         },
         index: {
           lineHeight: size + circleFontSize / 4 + 'px',
@@ -111,30 +127,30 @@ var Step = function (_Component) {
           position: 'absolute',
           top: circleTop + size / 2,
           height: 1,
-          borderTopStyle: barStyle || 'solid',
+          borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: defaultColor,
+          borderTopColor: barColor,
           left: 0,
           right: '50%',
-          marginRight: size / 2 + 1,
+          marginRight: size / 2 + 4,
           opacity: defaultOpcaity
         },
         rightBar: {
           position: 'absolute',
           top: circleTop + size / 2,
           height: 1,
-          borderTopStyle: barStyle || 'solid',
+          borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: defaultColor,
+          borderTopColor: barColor,
           right: 0,
           left: '50%',
-          marginLeft: size / 2 + 1,
+          marginLeft: size / 2 + 4,
           opacity: defaultOpcaity
         },
         completedBar: {
-          borderTopStyle: barStyle || 'solid',
+          borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: completeColor,
+          borderTopColor: barColor,
           opacity: completeOpacity
         }
       };
@@ -208,7 +224,10 @@ Step.defaultProps = {
   circleFontSize: 16,
   titleFontSize: 16,
   circleTop: 24,
-  titleTop: 8
+  titleTop: 8,
+  barColor: '#E0E0E0',
+  barStyle: 'solid',
+  borderStyle: 'solid'
 };
 
 Step.propTypes = {
@@ -237,5 +256,12 @@ Step.propTypes = {
   completeTitleOpacity: _propTypes.PropTypes.string,
   activeTitleOpacity: _propTypes.PropTypes.string,
   defaultTitleOpacity: _propTypes.PropTypes.string,
-  barStyle: _propTypes.PropTypes.string
+  barStyle: _propTypes.PropTypes.string,
+  barColor: _propTypes.PropTypes.string,
+  defaultBorderColor: _propTypes.PropTypes.string,
+  completeBorderColor: _propTypes.PropTypes.string,
+  activeBorderColor: _propTypes.PropTypes.string,
+  defaultBorderStyle: _propTypes.PropTypes.string,
+  completeBorderStyle: _propTypes.PropTypes.string,
+  activeBorderStyle: _propTypes.PropTypes.string
 };

--- a/lib/Step.js
+++ b/lib/Step.js
@@ -56,7 +56,8 @@ var Step = function (_Component) {
           activeTitleOpacity = _props.activeTitleOpacity,
           defaultTitleOpacity = _props.defaultTitleOpacity,
           barStyle = _props.barStyle,
-          barColor = _props.barColor,
+          defaultBarColor = _props.defaultBarColor,
+          completeBarColor = _props.completeBarColor,
           defaultBorderColor = _props.defaultBorderColor,
           completeBorderColor = _props.completeBorderColor,
           activeBorderColor = _props.activeBorderColor,
@@ -129,7 +130,7 @@ var Step = function (_Component) {
           height: 1,
           borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: barColor,
+          borderTopColor: defaultBarColor,
           left: 0,
           right: '50%',
           marginRight: size / 2 + 4,
@@ -141,7 +142,7 @@ var Step = function (_Component) {
           height: 1,
           borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: barColor,
+          borderTopColor: defaultBarColor,
           right: 0,
           left: '50%',
           marginLeft: size / 2 + 4,
@@ -150,7 +151,7 @@ var Step = function (_Component) {
         completedBar: {
           borderTopStyle: barStyle,
           borderTopWidth: 1,
-          borderTopColor: barColor,
+          borderTopColor: completeBarColor,
           opacity: completeOpacity
         }
       };
@@ -225,7 +226,7 @@ Step.defaultProps = {
   titleFontSize: 16,
   circleTop: 24,
   titleTop: 8,
-  barColor: '#E0E0E0',
+  defaultBarColor: '#E0E0E0',
   barStyle: 'solid',
   borderStyle: 'solid'
 };
@@ -257,7 +258,8 @@ Step.propTypes = {
   activeTitleOpacity: _propTypes.PropTypes.string,
   defaultTitleOpacity: _propTypes.PropTypes.string,
   barStyle: _propTypes.PropTypes.string,
-  barColor: _propTypes.PropTypes.string,
+  defaultBarColor: _propTypes.PropTypes.string,
+  completeBarColor: _propTypes.PropTypes.string,
   defaultBorderColor: _propTypes.PropTypes.string,
   completeBorderColor: _propTypes.PropTypes.string,
   activeBorderColor: _propTypes.PropTypes.string,

--- a/lib/Stepper.js
+++ b/lib/Stepper.js
@@ -50,7 +50,14 @@ function Stepper(_ref) {
       completeTitleOpacity = _ref.completeTitleOpacity,
       activeTitleOpacity = _ref.activeTitleOpacity,
       defaultTitleOpacity = _ref.defaultTitleOpacity,
-      barStyle = _ref.barStyle;
+      barStyle = _ref.barStyle,
+      barColor = _ref.barColor,
+      defaultBorderColor = _ref.defaultBorderColor,
+      completeBorderColor = _ref.completeBorderColor,
+      activeBorderColor = _ref.activeBorderColor,
+      defaultBorderStyle = _ref.defaultBorderStyle,
+      completeBorderStyle = _ref.completeBorderStyle,
+      activeBorderStyle = _ref.activeBorderStyle;
 
   return _react2.default.createElement(
     'div',
@@ -88,7 +95,14 @@ function Stepper(_ref) {
           defaultTitleOpacity: defaultTitleOpacity,
           completeTitleOpacity: completeTitleOpacity,
           activeTitleOpacity: activeTitleOpacity,
-          barStyle: barStyle
+          barStyle: barStyle,
+          barColor: barColor,
+          defaultBorderColor: defaultBorderColor,
+          completeBorderColor: completeBorderColor,
+          activeBorderColor: activeBorderColor,
+          defaultBorderStyle: defaultBorderStyle,
+          completeBorderStyle: completeBorderStyle,
+          activeBorderStyle: activeBorderStyle
         });
       })
     )
@@ -120,7 +134,14 @@ Stepper.propTypes = {
   defaultTitleOpacity: _propTypes.PropTypes.string,
   completeTitleOpacity: _propTypes.PropTypes.string,
   activeTitleOpacity: _propTypes.PropTypes.string,
-  barStyle: _propTypes.PropTypes.string
+  barStyle: _propTypes.PropTypes.string,
+  barColor: _propTypes.PropTypes.string,
+  defaultBorderColor: _propTypes.PropTypes.string,
+  completeBorderColor: _propTypes.PropTypes.string,
+  activeBorderColor: _propTypes.PropTypes.string,
+  defaultBorderStyle: _propTypes.PropTypes.string,
+  completeBorderStyle: _propTypes.PropTypes.string,
+  activeBorderStyle: _propTypes.PropTypes.string
 };
 
 exports.default = Stepper;

--- a/lib/Stepper.js
+++ b/lib/Stepper.js
@@ -51,13 +51,14 @@ function Stepper(_ref) {
       activeTitleOpacity = _ref.activeTitleOpacity,
       defaultTitleOpacity = _ref.defaultTitleOpacity,
       barStyle = _ref.barStyle,
-      barColor = _ref.barColor,
       defaultBorderColor = _ref.defaultBorderColor,
       completeBorderColor = _ref.completeBorderColor,
       activeBorderColor = _ref.activeBorderColor,
       defaultBorderStyle = _ref.defaultBorderStyle,
       completeBorderStyle = _ref.completeBorderStyle,
-      activeBorderStyle = _ref.activeBorderStyle;
+      activeBorderStyle = _ref.activeBorderStyle,
+      defaultBarColor = _ref.defaultBarColor,
+      completeBarColor = _ref.completeBarColor;
 
   return _react2.default.createElement(
     'div',
@@ -96,13 +97,14 @@ function Stepper(_ref) {
           completeTitleOpacity: completeTitleOpacity,
           activeTitleOpacity: activeTitleOpacity,
           barStyle: barStyle,
-          barColor: barColor,
           defaultBorderColor: defaultBorderColor,
           completeBorderColor: completeBorderColor,
           activeBorderColor: activeBorderColor,
           defaultBorderStyle: defaultBorderStyle,
           completeBorderStyle: completeBorderStyle,
-          activeBorderStyle: activeBorderStyle
+          activeBorderStyle: activeBorderStyle,
+          defaultBarColor: defaultBarColor,
+          completeBarColor: completeBarColor
         });
       })
     )
@@ -135,7 +137,8 @@ Stepper.propTypes = {
   completeTitleOpacity: _propTypes.PropTypes.string,
   activeTitleOpacity: _propTypes.PropTypes.string,
   barStyle: _propTypes.PropTypes.string,
-  barColor: _propTypes.PropTypes.string,
+  defaultBarColor: _propTypes.PropTypes.string,
+  completeBarColor: _propTypes.PropTypes.string,
   defaultBorderColor: _propTypes.PropTypes.string,
   completeBorderColor: _propTypes.PropTypes.string,
   activeBorderColor: _propTypes.PropTypes.string,

--- a/src/Step.js
+++ b/src/Step.js
@@ -13,9 +13,9 @@ export default class Step extends Component {
       activeTitleColor, completeTitleColor, defaultTitleColor,
       size, circleFontSize, titleFontSize,
       circleTop, titleTop, width, completeOpacity, activeOpacity, defaultOpcaity,
-      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle,
+      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, barColor,
       defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
-      completeBorderStyle, activeBorderStyle,
+      completeBorderStyle, activeBorderStyle
     } = this.props;
 
     return {
@@ -37,19 +37,21 @@ export default class Step extends Component {
         color: circleFontColor,
         display: 'block',
         opacity: defaultOpcaity,
-        borderWidth: (defaultBorderColor ? 4 : 0),
+        borderWidth: (defaultBorderColor ? 3 : 0),
         borderColor: defaultBorderColor,
-        borderStyle: defaultBorderStyle || 'solid',
+        borderStyle: defaultBorderStyle
       },
       activeCircle: {
         backgroundColor: activeColor,
         opacity: activeOpacity,
+        borderWidth: (activeBorderColor ? 3 : 0),
         borderColor: activeBorderColor,
         borderStyle: activeBorderStyle,
       },
       completedCircle: {
         backgroundColor: completeColor,
         opacity: completeOpacity,
+        borderWidth: (completeBorderColor ? 3 : 0),
         borderColor: completeBorderColor,
         borderStyle: completeBorderStyle,
       },
@@ -78,30 +80,30 @@ export default class Step extends Component {
         position: 'absolute',
         top: circleTop + size / 2,
         height: 1,
-        borderTopStyle: barStyle || 'solid',
+        borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: defaultColor,
+        borderTopColor: barColor,
         left: 0,
         right: '50%',
-        marginRight: size / 2 + 1,
+        marginRight: size / 2 + 4,
         opacity: defaultOpcaity,
       },
       rightBar: {
         position: 'absolute',
         top: circleTop + size / 2,
         height: 1,
-        borderTopStyle: barStyle || 'solid',
+        borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: defaultColor,
+        borderTopColor: barColor,
         right: 0,
         left: '50%',
-        marginLeft: size / 2 + 1,
+        marginLeft: size / 2 + 4,
         opacity: defaultOpcaity,
       },
       completedBar: {
-        borderTopStyle: barStyle || 'solid',
+        borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: completeColor,
+        borderTopColor: barColor,
         opacity: completeOpacity,
       },
     };
@@ -158,6 +160,9 @@ Step.defaultProps = {
   titleFontSize: 16,
   circleTop: 24,
   titleTop: 8,
+  barColor: '#E0E0E0',
+  barStyle: 'solid',
+  borderStyle: 'solid',
 };
 
 Step.propTypes = {
@@ -187,6 +192,7 @@ Step.propTypes = {
   activeTitleOpacity: PropTypes.string,
   defaultTitleOpacity: PropTypes.string,
   barStyle: PropTypes.string,
+  barColor: PropTypes.string,
   defaultBorderColor: PropTypes.string,
   completeBorderColor: PropTypes.string,
   activeBorderColor: PropTypes.string,

--- a/src/Step.js
+++ b/src/Step.js
@@ -13,7 +13,9 @@ export default class Step extends Component {
       activeTitleColor, completeTitleColor, defaultTitleColor,
       size, circleFontSize, titleFontSize,
       circleTop, titleTop, width, completeOpacity, activeOpacity, defaultOpcaity,
-      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle
+      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle,
+      defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
+      completeBorderStyle, activeBorderStyle,
     } = this.props;
 
     return {
@@ -35,14 +37,21 @@ export default class Step extends Component {
         color: circleFontColor,
         display: 'block',
         opacity: defaultOpcaity,
+        borderWidth: (defaultBorderColor ? 4 : 0),
+        borderColor: defaultBorderColor,
+        borderStyle: defaultBorderStyle || 'solid',
       },
       activeCircle: {
         backgroundColor: activeColor,
         opacity: activeOpacity,
+        borderColor: activeBorderColor,
+        borderStyle: activeBorderStyle,
       },
       completedCircle: {
         backgroundColor: completeColor,
         opacity: completeOpacity,
+        borderColor: completeBorderColor,
+        borderStyle: completeBorderStyle,
       },
       index: {
         lineHeight: `${size + circleFontSize / 4}px`,
@@ -177,5 +186,11 @@ Step.propTypes = {
   completeTitleOpacity: PropTypes.string,
   activeTitleOpacity: PropTypes.string,
   defaultTitleOpacity: PropTypes.string,
-  barStyle: PropTypes.string
+  barStyle: PropTypes.string,
+  defaultBorderColor: PropTypes.string,
+  completeBorderColor: PropTypes.string,
+  activeBorderColor: PropTypes.string,
+  defaultBorderStyle: PropTypes.string,
+  completeBorderStyle: PropTypes.string,
+  activeBorderStyle: PropTypes.string
 };

--- a/src/Step.js
+++ b/src/Step.js
@@ -13,9 +13,9 @@ export default class Step extends Component {
       activeTitleColor, completeTitleColor, defaultTitleColor,
       size, circleFontSize, titleFontSize,
       circleTop, titleTop, width, completeOpacity, activeOpacity, defaultOpcaity,
-      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, barColor,
-      defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
-      completeBorderStyle, activeBorderStyle
+      completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, defaultBarColor,
+      completeBarColor, defaultBorderColor, completeBorderColor, activeBorderColor,
+      defaultBorderStyle,completeBorderStyle, activeBorderStyle
     } = this.props;
 
     return {
@@ -82,7 +82,7 @@ export default class Step extends Component {
         height: 1,
         borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: barColor,
+        borderTopColor: defaultBarColor,
         left: 0,
         right: '50%',
         marginRight: size / 2 + 4,
@@ -94,7 +94,7 @@ export default class Step extends Component {
         height: 1,
         borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: barColor,
+        borderTopColor: defaultBarColor,
         right: 0,
         left: '50%',
         marginLeft: size / 2 + 4,
@@ -103,7 +103,7 @@ export default class Step extends Component {
       completedBar: {
         borderTopStyle: barStyle,
         borderTopWidth: 1,
-        borderTopColor: barColor,
+        borderTopColor: completeBarColor,
         opacity: completeOpacity,
       },
     };
@@ -160,7 +160,7 @@ Step.defaultProps = {
   titleFontSize: 16,
   circleTop: 24,
   titleTop: 8,
-  barColor: '#E0E0E0',
+  defaultBarColor: '#E0E0E0',
   barStyle: 'solid',
   borderStyle: 'solid',
 };
@@ -192,7 +192,8 @@ Step.propTypes = {
   activeTitleOpacity: PropTypes.string,
   defaultTitleOpacity: PropTypes.string,
   barStyle: PropTypes.string,
-  barColor: PropTypes.string,
+  defaultBarColor: PropTypes.string,
+  completeBarColor: PropTypes.string,
   defaultBorderColor: PropTypes.string,
   completeBorderColor: PropTypes.string,
   activeBorderColor: PropTypes.string,

--- a/src/Stepper.js
+++ b/src/Stepper.js
@@ -22,9 +22,9 @@ function Stepper({
   activeTitleColor, completeTitleColor, defaultTitleColor,
   size, circleFontSize, titleFontSize,
   circleTop, titleTop, completeOpacity, activeOpacity, defaultOpcaity,
-  completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, barColor,
+  completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle,
   defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
-  completeBorderStyle, activeBorderStyle,
+  completeBorderStyle, activeBorderStyle, defaultBarColor, completeBarColor
 }) {
   return (
     <div style={ styles.root }>
@@ -60,13 +60,14 @@ function Stepper({
             completeTitleOpacity={completeTitleOpacity}
             activeTitleOpacity={activeTitleOpacity}
             barStyle={barStyle}
-            barColor={barColor}
             defaultBorderColor={defaultBorderColor}
             completeBorderColor={completeBorderColor}
             activeBorderColor={activeBorderColor}
             defaultBorderStyle={defaultBorderStyle}
             completeBorderStyle={completeBorderStyle}
             activeBorderStyle={activeBorderStyle}
+            defaultBarColor={defaultBarColor}
+            completeBarColor={completeBarColor}
           />
         )) }
       </div>
@@ -100,7 +101,8 @@ Stepper.propTypes = {
   completeTitleOpacity: PropTypes.string,
   activeTitleOpacity: PropTypes.string,
   barStyle: PropTypes.string,
-  barColor: PropTypes.string,
+  defaultBarColor: PropTypes.string,
+  completeBarColor: PropTypes.string,
   defaultBorderColor: PropTypes.string,
   completeBorderColor: PropTypes.string,
   activeBorderColor: PropTypes.string,

--- a/src/Stepper.js
+++ b/src/Stepper.js
@@ -58,6 +58,12 @@ function Stepper({
             completeTitleOpacity={completeTitleOpacity}
             activeTitleOpacity={activeTitleOpacity}
             barStyle={barStyle}
+            defaultBorderColor={defaultBorderColor}
+            completeBorderColor={completeBorderColor}
+            activeBorderColor={activeBorderColor}
+            defaultBorderStyle={defaultBorderStyle}
+            completeBorderStyle={completeBorderStyle}
+            activeBorderStyle={activeBorderStyle}
           />
         )) }
       </div>
@@ -91,6 +97,12 @@ Stepper.propTypes = {
   completeTitleOpacity: PropTypes.string,
   activeTitleOpacity: PropTypes.string,
   barStyle: PropTypes.string,
+  defaultBorderColor: PropTypes.string,
+  completeBorderColor: PropTypes.string,
+  activeBorderColor: PropTypes.string,
+  defaultBorderStyle: PropTypes.string,
+  completeBorderStyle: PropTypes.string,
+  activeBorderStyle: PropTypes.string,
 };
 
 export default Stepper;

--- a/src/Stepper.js
+++ b/src/Stepper.js
@@ -22,7 +22,9 @@ function Stepper({
   activeTitleColor, completeTitleColor, defaultTitleColor,
   size, circleFontSize, titleFontSize,
   circleTop, titleTop, completeOpacity, activeOpacity, defaultOpcaity,
-  completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle
+  completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, barColor,
+  defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
+  completeBorderStyle, activeBorderStyle,
 }) {
   return (
     <div style={ styles.root }>
@@ -58,6 +60,7 @@ function Stepper({
             completeTitleOpacity={completeTitleOpacity}
             activeTitleOpacity={activeTitleOpacity}
             barStyle={barStyle}
+            barColor={barColor}
             defaultBorderColor={defaultBorderColor}
             completeBorderColor={completeBorderColor}
             activeBorderColor={activeBorderColor}
@@ -97,6 +100,7 @@ Stepper.propTypes = {
   completeTitleOpacity: PropTypes.string,
   activeTitleOpacity: PropTypes.string,
   barStyle: PropTypes.string,
+  barColor: PropTypes.string,
   defaultBorderColor: PropTypes.string,
   completeBorderColor: PropTypes.string,
   activeBorderColor: PropTypes.string,


### PR DESCRIPTION
### What did I add?
 * Added fixed in size, optional borders (set by just adding a defaultBorderColor prop. Works the same for complete and active. For the time being the width is set to 3 because if it isn't a hardcoded value then the bars need to be repositioned based on the width of the border. It really isn't worth doing. 
* Added borderStyle (default is solid, but dashed and dotted are nice in some situations
* Added defaultBarColor and completeBarColor. Originally the bar color was inherited from the circle color, but with borders it is often nice to have a transparent background for the circles and with the old model for adding bar color the bar would also become transparent.
* Updated the README.md with these new props.

Please let me know if you see anything incorrect about what I've added or if you see an opportunity for improvement. I will be happy to fix it.
