### PR TITLE
Fixed all occurrences of "opcaity"

### DIFF
--- a/lib/Step.js
+++ b/lib/Step.js
@@ -35,7 +35,6 @@ var Step = function (_Component) {
   _createClass(Step, [{
     key: 'getStyles',
     value: function getStyles() {
-
       var _props = this.props,
           activeColor = _props.activeColor,
           completeColor = _props.completeColor,
@@ -52,7 +51,7 @@ var Step = function (_Component) {
           width = _props.width,
           completeOpacity = _props.completeOpacity,
           activeOpacity = _props.activeOpacity,
-          defaultOpcaity = _props.defaultOpcaity,
+          defaultOpacity = _props.defaultOpacity,
           completeTitleOpacity = _props.completeTitleOpacity,
           activeTitleOpacity = _props.activeTitleOpacity,
           defaultTitleOpacity = _props.defaultTitleOpacity,
@@ -65,6 +64,7 @@ var Step = function (_Component) {
           defaultBorderStyle = _props.defaultBorderStyle,
           completeBorderStyle = _props.completeBorderStyle,
           activeBorderStyle = _props.activeBorderStyle;
+
 
       return {
         step: {
@@ -84,7 +84,7 @@ var Step = function (_Component) {
           fontSize: circleFontSize,
           color: circleFontColor,
           display: 'block',
-          opacity: defaultOpcaity,
+          opacity: defaultOpacity,
           borderWidth: defaultBorderColor ? 3 : 0,
           borderColor: defaultBorderColor,
           borderStyle: defaultBorderStyle
@@ -134,7 +134,7 @@ var Step = function (_Component) {
           left: 0,
           right: '50%',
           marginRight: size / 2 + 4,
-          opacity: defaultOpcaity
+          opacity: defaultOpacity
         },
         rightBar: {
           position: 'absolute',
@@ -146,7 +146,7 @@ var Step = function (_Component) {
           right: 0,
           left: '50%',
           marginLeft: size / 2 + 4,
-          opacity: defaultOpcaity
+          opacity: defaultOpacity
         },
         completedBar: {
           borderTopStyle: barStyle,
@@ -159,15 +159,15 @@ var Step = function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props2 = this.props;
-      var title = _props2.title;
-      var index = _props2.index;
-      var active = _props2.active;
-      var completed = _props2.completed;
-      var first = _props2.first;
-      var isLast = _props2.isLast;
-      var href = _props2.href;
-      var onClick = _props2.onClick;
+      var _props2 = this.props,
+          title = _props2.title,
+          index = _props2.index,
+          active = _props2.active,
+          completed = _props2.completed,
+          first = _props2.first,
+          isLast = _props2.isLast,
+          href = _props2.href,
+          onClick = _props2.onClick;
 
 
       var styles = this.getStyles();
@@ -253,7 +253,7 @@ Step.propTypes = {
   isLast: _propTypes.PropTypes.bool,
   completeOpacity: _propTypes.PropTypes.string,
   activeOpacity: _propTypes.PropTypes.string,
-  defaultOpcaity: _propTypes.PropTypes.string,
+  defaultOpacity: _propTypes.PropTypes.string,
   completeTitleOpacity: _propTypes.PropTypes.string,
   activeTitleOpacity: _propTypes.PropTypes.string,
   defaultTitleOpacity: _propTypes.PropTypes.string,

--- a/lib/Stepper.js
+++ b/lib/Stepper.js
@@ -30,7 +30,6 @@ var styles = {
 };
 
 function Stepper(_ref) {
-
   var activeStep = _ref.activeStep,
       steps = _ref.steps,
       activeColor = _ref.activeColor,
@@ -47,7 +46,7 @@ function Stepper(_ref) {
       titleTop = _ref.titleTop,
       completeOpacity = _ref.completeOpacity,
       activeOpacity = _ref.activeOpacity,
-      defaultOpcaity = _ref.defaultOpcaity,
+      defaultOpacity = _ref.defaultOpacity,
       completeTitleOpacity = _ref.completeTitleOpacity,
       activeTitleOpacity = _ref.activeTitleOpacity,
       defaultTitleOpacity = _ref.defaultTitleOpacity,
@@ -91,7 +90,7 @@ function Stepper(_ref) {
           titleFontSize: titleFontSize,
           circleTop: circleTop,
           titleTop: titleTop,
-          defaultOpcaity: defaultOpcaity,
+          defaultOpacity: defaultOpacity,
           completeOpacity: completeOpacity,
           activeOpacity: activeOpacity,
           defaultTitleOpacity: defaultTitleOpacity,
@@ -131,7 +130,7 @@ Stepper.propTypes = {
   titleFontSize: _propTypes.PropTypes.number,
   circleTop: _propTypes.PropTypes.number,
   titleTop: _propTypes.PropTypes.number,
-  defaultOpcaity: _propTypes.PropTypes.string,
+  defaultOpacity: _propTypes.PropTypes.string,
   completeOpacity: _propTypes.PropTypes.string,
   activeOpacity: _propTypes.PropTypes.string,
   defaultTitleOpacity: _propTypes.PropTypes.string,

--- a/src/Step.js
+++ b/src/Step.js
@@ -12,7 +12,7 @@ export default class Step extends Component {
       activeColor, completeColor, defaultColor, circleFontColor,
       activeTitleColor, completeTitleColor, defaultTitleColor,
       size, circleFontSize, titleFontSize,
-      circleTop, titleTop, width, completeOpacity, activeOpacity, defaultOpcaity,
+      circleTop, titleTop, width, completeOpacity, activeOpacity, defaultOpacity,
       completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle, defaultBarColor,
       completeBarColor, defaultBorderColor, completeBorderColor, activeBorderColor,
       defaultBorderStyle,completeBorderStyle, activeBorderStyle
@@ -36,7 +36,7 @@ export default class Step extends Component {
         fontSize: circleFontSize,
         color: circleFontColor,
         display: 'block',
-        opacity: defaultOpcaity,
+        opacity: defaultOpacity,
         borderWidth: (defaultBorderColor ? 3 : 0),
         borderColor: defaultBorderColor,
         borderStyle: defaultBorderStyle
@@ -86,7 +86,7 @@ export default class Step extends Component {
         left: 0,
         right: '50%',
         marginRight: size / 2 + 4,
-        opacity: defaultOpcaity,
+        opacity: defaultOpacity,
       },
       rightBar: {
         position: 'absolute',
@@ -98,7 +98,7 @@ export default class Step extends Component {
         right: 0,
         left: '50%',
         marginLeft: size / 2 + 4,
-        opacity: defaultOpcaity,
+        opacity: defaultOpacity,
       },
       completedBar: {
         borderTopStyle: barStyle,
@@ -187,7 +187,7 @@ Step.propTypes = {
   isLast: PropTypes.bool,
   completeOpacity: PropTypes.string,
   activeOpacity: PropTypes.string,
-  defaultOpcaity: PropTypes.string,
+  defaultOpacity: PropTypes.string,
   completeTitleOpacity: PropTypes.string,
   activeTitleOpacity: PropTypes.string,
   defaultTitleOpacity: PropTypes.string,

--- a/src/Stepper.js
+++ b/src/Stepper.js
@@ -21,7 +21,7 @@ function Stepper({
   activeColor, completeColor, defaultColor, circleFontColor,
   activeTitleColor, completeTitleColor, defaultTitleColor,
   size, circleFontSize, titleFontSize,
-  circleTop, titleTop, completeOpacity, activeOpacity, defaultOpcaity,
+  circleTop, titleTop, completeOpacity, activeOpacity, defaultOpacity,
   completeTitleOpacity, activeTitleOpacity, defaultTitleOpacity, barStyle,
   defaultBorderColor, completeBorderColor, activeBorderColor, defaultBorderStyle,
   completeBorderStyle, activeBorderStyle, defaultBarColor, completeBarColor
@@ -53,7 +53,7 @@ function Stepper({
             titleFontSize={titleFontSize}
             circleTop={circleTop}
             titleTop={titleTop}
-            defaultOpcaity={defaultOpcaity}
+            defaultOpacity={defaultOpacity}
             completeOpacity={completeOpacity}
             activeOpacity={activeOpacity}
             defaultTitleOpacity={defaultTitleOpacity}
@@ -94,7 +94,7 @@ Stepper.propTypes = {
   titleFontSize: PropTypes.number,
   circleTop: PropTypes.number,
   titleTop: PropTypes.number,
-  defaultOpcaity: PropTypes.string,
+  defaultOpacity: PropTypes.string,
   completeOpacity: PropTypes.string,
   activeOpacity: PropTypes.string,
   defaultTitleOpacity: PropTypes.string,


### PR DESCRIPTION
Due in part to my incompetence and Atom's auto-complete feature I managed to misspell every occurrence of the word "opacity" inside of the prop defaultOpacity. The prop was working correctly as long as the user set "defaultOpcaity" instead of "defaultOpacity". I have fixed this and everything is working as it should. I'll be sure to double check for things like this in the future.
Sorry for the inconvenience!
